### PR TITLE
Release v1.2.2

### DIFF
--- a/.github/workflows/pio_build.yml
+++ b/.github/workflows/pio_build.yml
@@ -39,24 +39,41 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: PIO Cache
+      - name: PIP Cache
+        id: cache-pip
         uses: actions/cache@v4
+        env:
+          cache-name: cache-pip-pkgs
         with:
           path: |
             ~/.cache/pip
-            ~/.platformio/.cache
-          key: ${{ runner.os }}-pio
-          #restore-keys: |
-          #  ${{ runner.os }}-pio
+          key: ${{ runner.os }}-pip-${{env.cache-name}}
+          restore-keys: |
+            ${{ runner.os }}-pip
+            ${{ runner.os }}
+      - name: Platformio Cache
+        id: cache-pio
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-pio-pkgs
+        with:
+          path: |
+            ~/.platformio/platforms
+            ~/.platformio/packages
+          key: ${{ runner.os }}-pio-${{env.cache-name}}
+          restore-keys: |
+            ${{ runner.os }}-pio-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+
       - name: Install Platformio
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade platformio
           #platformio pkg update
+
       - name: PIO build
         env: 
           PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## release v1.2.2
+_other_
+  silense some compiller warning in C++17
+
 ## release v1.2.1
 _new features:_
   add PseudoRotaryEncoder::enable, PseudoRotaryEncoder::disable calls

--- a/examples/00_AsyncEventButton/platformio.ini
+++ b/examples/00_AsyncEventButton/platformio.ini
@@ -14,7 +14,12 @@ monitor_speed = 115200
 
 [esp32_base]
 extends = common
-platform = espressif32
+; PIOArduino stable
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; PIOArduino Dev
+;platform = https://github.com/pioarduino/platform-espressif32.git#develop
+; old Core 2.x
+;platform = espressif32
 board = wemos_d1_mini32
 upload_speed = 460800
 monitor_filters = esp32_exception_decoder

--- a/examples/01_BasicEvents/platformio.ini
+++ b/examples/01_BasicEvents/platformio.ini
@@ -14,7 +14,12 @@ monitor_speed = 115200
 
 [esp32_base]
 extends = common
-platform = espressif32
+; PIOArduino stable
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; PIOArduino Dev
+;platform = https://github.com/pioarduino/platform-espressif32.git#develop
+; old Core 2.x
+;platform = espressif32
 board = wemos_d1_mini32
 upload_speed = 460800
 monitor_filters = esp32_exception_decoder

--- a/examples/02_CallbackMenu/platformio.ini
+++ b/examples/02_CallbackMenu/platformio.ini
@@ -14,7 +14,12 @@ monitor_speed = 115200
 
 [esp32_base]
 extends = common
-platform = espressif32
+; PIOArduino stable
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; PIOArduino Dev
+;platform = https://github.com/pioarduino/platform-espressif32.git#develop
+; old Core 2.x
+;platform = espressif32
 board = wemos_d1_mini32
 upload_speed = 460800
 monitor_filters = esp32_exception_decoder

--- a/examples/03_PseudoEncoder/platformio.ini
+++ b/examples/03_PseudoEncoder/platformio.ini
@@ -14,7 +14,12 @@ monitor_speed = 115200
 
 [esp32_base]
 extends = common
-platform = espressif32
+; PIOArduino stable
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; PIOArduino Dev
+;platform = https://github.com/pioarduino/platform-espressif32.git#develop
+; old Core 2.x
+;platform = espressif32
 board = wemos_d1_mini32
 upload_speed = 460800
 monitor_filters = esp32_exception_decoder

--- a/library.json
+++ b/library.json
@@ -4,7 +4,7 @@
     "frameworks": "arduino",
     "platforms": ["espressif32"],
     "url": "https://github.com/vortigont/ESPAsyncButton",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "keywords": "input, button, event",
     "authors": [
         {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESPAsyncButton
-version=1.2.1
+version=1.2.2
 author=Emil Muratov
 maintainer=Emil Muratov
 sentence=Event-driven asynchronous button toolkit for ESP32

--- a/src/espasyncbutton.hpp
+++ b/src/espasyncbutton.hpp
@@ -101,13 +101,12 @@ namespace ESPButton {
    * @tparam T 
    */
   template <class T>
-  class MatchEventCallback : public std::unary_function<T, bool>{
+  struct MatchEventCallback {
       int32_t _gpio;
       uint32_t _menu;
 
-  public:
       explicit MatchEventCallback(uint32_t gpio, uint32_t menu) : _gpio(gpio), _menu(menu) {}
-      bool operator() ( T val ){
+      constexpr bool operator() ( T val ) const {
           // T is struct EventCallback
           return val.gpio == _gpio && val.menulvl == _menu;
       }


### PR DESCRIPTION
 - set platformio core to pioarduino in example
 - remove std::unary_function inheritance as obsolete
 - silence some compiler warnings
